### PR TITLE
Master

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ ifneq (,$(wildcard .svn))
 else ifneq (,$(wildcard .git))
  VCSREV = $(shell head -1 .git/refs/heads/master | cut -c 1-7)
 endif
-VERSION = 2.0
+VERSION = 1.6
 REL_DIR = $(VERSION)-$(VCSREV)
 
 export OPT_LVL = -g -O2

--- a/ht_lib/host/HtHif.cpp
+++ b/ht_lib/host/HtHif.cpp
@@ -291,6 +291,24 @@ namespace Ht {
 			free(pMem);
 #		endif
 	}
+        void * CHtHifBase::HostMemAllocHuge(void* hostBaseAddr)
+	{
+	    int flags = MAP_PRIVATE;
+	    flags |= (MAP_ANONYMOUS | MAP_POPULATE | MAP_HUGETLB | MAP_FIXED);
+            size_t const HugePageSize = 1*1024*1024*1024;
+	    void * pMem = mmap(hostBaseAddr, HugePageSize, PROT_READ|PROT_WRITE, flags, -1, 0);
+	    if (pMem == nullptr)
+		fprintf(stderr, "HTLIB: Host huge page alloc failed (0x%llx, 0x%llx)\n",
+			(long long)HugePageSize, (long long)hostBaseAddr);
+	    return pMem;
+	}
+	void CHtHifBase::HostMemFreeHuge(void * pMem) {
+            size_t const HugePageSize = 1*1024*1024*1024;
+	    munlock(pMem, HugePageSize);
+	    if (munmap(pMem, HugePageSize) != 0)
+		fprintf(stderr, "HTLIB: Host huge free failed (0x%llx)\n",
+			(long long)pMem);
+	}
 
 	void * CHtHifBase::MemAlloc(size_t size) {
 #		if !defined(HT_SYSC) && !defined(HT_MODEL) && !defined(_WIN32)

--- a/ht_lib/host/HtHifLib.cpp
+++ b/ht_lib/host/HtHifLib.cpp
@@ -149,7 +149,16 @@ namespace Ht {
 		delete[] ppMemRegion;
 
 		size_t memAlign = 4*1024*1024;
-		if (!(m_pHtHifMem = (uint8_t *)CHtHif::HostMemAllocAlign(memAlign, m_htHifMemSize, false))) {
+		if (pHtHifBase->m_htHifParams.m_hostMemHugePageBase) {
+			if (m_htHifMemSize > HugePageSize)
+				throw CHtException(eHtBadHostAlloc, string("HostMemAllocHuge is currently limited to a single 1GB page"));
+			m_pHtHifMem = (uint8_t *)CHtHif::HostMemAllocHuge(pHtHifBase->m_htHifParams.m_hostMemHugePageBase);
+			m_pHtHifMemHuge = true;
+		} else {
+			m_pHtHifMem = (uint8_t *)CHtHif::HostMemAllocAlign(memAlign, m_htHifMemSize, false);
+			m_pHtHifMemHuge = false;
+		}
+		if (!m_pHtHifMem) {
 			if (m_pMemRegionList) {
 				delete[] m_pMemRegionList;
 				m_pMemRegionList = 0;
@@ -358,11 +367,11 @@ namespace Ht {
 		UnlockInBlk();
 	}
 
-	CHtHifLibBase * CHtHifLibBase::NewHtHifLibBase(CHtHifParams * pHtHifParams, char const * pHtPers, CHtHifBase * pHtHifBase) {
-		return new CHtHifLib(pHtHifParams, pHtPers, pHtHifBase);
+	CHtHifLibBase * CHtHifLibBase::NewHtHifLibBase(CHtHifParams * pHtHifParams, char const * pHtPers, CHtHifBase * pHtHifBase, bool pHtHifHuge) {
+		return new CHtHifLib(pHtHifParams, pHtPers, pHtHifBase, pHtHifHuge);
 	}
 
-	CHtHifLib::CHtHifLib(CHtHifParams * pHtHifParams, char const * pHtPers, CHtHifBase * pHtHifBase)
+	CHtHifLib::CHtHifLib(CHtHifParams * pHtHifParams, char const * pHtPers, CHtHifBase * pHtHifBase, bool pHtHifHuge)
 	{
 		m_pHtHifBase = pHtHifBase;
 		m_ppHtUnits = 0;


### PR DESCRIPTION
Adds support for 1GB huge page allocations for host-resident buffers.
Created HostMemAllocHuge() and HostMemFreeHuge().  Calls these instead of HostMemAllocAlign() when requested, by new parameter. 
THIS CHANGE WAS MADE TO VERSION 1.4. 
