### PR TITLE
remove obsolete std::gets(), seen with Fedora25

### DIFF
--- a/import/patches-2.3.1/header.patch
+++ b/import/patches-2.3.1/header.patch
@@ -1,0 +1,10 @@
+--- src/systemc.h	2014-04-17 11:32:26.000000000 -0500
++++ src/systemc.h	2017-03-03 14:41:07.212776380 -0600
+@@ -115,7 +115,6 @@
+     using std::fputs;
+     using std::getc;
+     using std::getchar;
+-    using std::gets;
+     using std::putc;
+     using std::putchar;
+     using std::puts;

--- a/import/patches-2.3.1/order.txt
+++ b/import/patches-2.3.1/order.txt
@@ -1,3 +1,4 @@
+header.patch
 sc_vcd_trace.patch
 convey_vcd.patch
 convey_msvs.patch


### PR DESCRIPTION
Let's try this GitHub thingy